### PR TITLE
Fix typos and misspellings across RFC documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ engage in such discussions.
 
 If you'd like the subject to be discussed before jumping into a formal RFC, you can create an [issue](https://github.com/mulesoft-labs/data-weave-rfc/issues/new) explaining the idea or the problem you'd like to solve. A corresponding [proposal](https://github.com/mulesoft-labs/data-weave-rfc/tree/master/proposals) can be merged simultaneously to later expedite the RFC process. Once you are ready to move forward, the proper RFC can be created.
 
-To get a substaintial change accepted into the DataWeave language, you must first get the corresponding RFC merged into this repository as a markdown file. At this point the RFC is "active" and may be implemented and eventually included in DataWeave. 
+To get a substantial change accepted into the DataWeave language, you must first get the corresponding RFC merged into this repository as a markdown file. At this point the RFC is "active" and may be implemented and eventually included in DataWeave. 
 
 The process is as follows:
 

--- a/blogs/Streaming.md
+++ b/blogs/Streaming.md
@@ -3,12 +3,12 @@
 ## Collections in DataWeave
 
 
-DataWeave has two kind of collections *Array* and *Object*. 
+DataWeave has two kinds of collections *Array* and *Object*. 
 
 * Array: is a sequence of values 
 * Object: is a sequence of key value pairs.
 
-Our collections are inmutable (as everything in DataWeave) they allow random access and being consumed multiple times. This model is very simple to understand and consume.
+Our collections are immutable (as everything in DataWeave) they allow random access and being consumed multiple times. This model is very simple to understand and consume.
 
 In order to support this model and also tried to be memory efficient we designed our collections to support two different models. An Array kind and an Iterator kind.
 
@@ -16,15 +16,15 @@ The Array kind is the simplest as it supports directly all the requirements. We 
 
 
 The idea of this blog is to describe how we pick and switch between the two models.
-As described previously our collections support random access and can be consumed multiple times, but that doesn't mean it is being consumed multiple times or in a random access way. So the idea is that if we can determine that a variable is consumed only once and in a sequencial manner we can use the streaming mode in a secure way if not the value needs to be materialized.
+As described previously our collections support random access and can be consumed multiple times, but that doesn't mean it is being consumed multiple times or in a random access way. So the idea is that if we can determine that a variable is consumed only once and in a sequential manner we can use the streaming mode in a secure way if not the value needs to be materialized.
 
-To determine if a variable needs to be materialized we do a code analysis (similar to scape analysis idea on compilers optimization). Using [linear logic](https://en.wikipedia.org/wiki/Substructural_type_system#Linear_type_systems)    we can determine if a variable is access in a secuencial maner and only once.
+To determine if a variable needs to be materialized we do a code analysis (similar to escape analysis idea on compilers optimization). Using [linear logic](https://en.wikipedia.org/wiki/Substructural_type_system#Linear_type_systems)    we can determine if a variable is accessed in a sequential manner and only once.
 
 Our approach is to validate a few rules 
 
-1. The variable is only reference once
-2. The variable is access in the same scope as it was defined
-3. Only sequencial access is allowed
+1. The variable is only referenced once
+2. The variable is accessed in the same scope as it was defined
+3. Only sequential access is allowed
 
 Let's view some example
 
@@ -37,7 +37,7 @@ var a = 1 to 100000
 a[1] + a[0]
 ```
 
-This case shows a clear example of a non linear access to the variable `a` why? because it access the variable `a` it accessed more than once and it is access in a random way. This breakes rule number 1
+This case shows a clear example of a non linear access to the variable `a` why? because it access the variable `a` it accessed more than once and it is access in a random way. This breaks rule number 1
 
 
 
@@ -51,7 +51,7 @@ var a = 1 to 100000
 a << 2 
 ```
 
-This example shows an example where materialization is not required as the variable a is only access once and in a sequencial order.
+This example shows an example where materialization is not required as the variable a is only access once and in a sequential order.
 
 # example 3
 
@@ -64,7 +64,7 @@ var a = 1 to 100000
 [1,2,3] map ((item) -> a)
 ```
 
-This is a more complex scenario even if there is only one refrence to the variable. The reference is inside another scope that it was defined. It is inside a lambda and that lambda is going to be executed multiple times. This breaks rule number 2
+This is a more complex scenario even if there is only one reference to the variable. The reference is inside another scope than it was defined. It is inside a lambda and that lambda is going to be executed multiple times. This breaks rule number 2
 
 
  # example 4
@@ -81,7 +81,7 @@ fun addToEach(a: Array<Number>, amount: Number) =
 
 ```
 
-In this example variable `a` is streamed because it is being consumed only once and in a sequencial way. The head and tail deconstructor `[x ~ xs]` garanties that the access is sequencial.
+In this example variable `a` is streamed because it is being consumed only once and in a sequential way. The head and tail deconstructor `[x ~ xs]` guarantees that the access is sequential.
 
 
 ## Streaming
@@ -90,5 +90,5 @@ In this example variable `a` is streamed because it is being consumed only once 
 Now that we understand the how our collections work we can analyze when an input is ready for streaming or not. If an input is never going to be materialized then we can use the streaming parser for this input.
 
 
-There is a way to verify that an input can be streamed through the script an is by annotating an input with the @StreamCapable annotation.
+There is a way to verify that an input can be streamed through the script and is by annotating an input with the @StreamCapable annotation.
 By using this annotation DW will fail if any random access is being used over this input. This validation is being done by analyzing not just direct access but also any re assignment or function call.

--- a/proposals/Directives.md
+++ b/proposals/Directives.md
@@ -1,6 +1,6 @@
 # Evolve Input Directive
 
-Input directives have caused us problems specially in mule land where all inputs are implicits 
+Input directives have caused us problems especially in mule land where all inputs are implicits 
 and reader configuration are taken from the values mime types. What happen is that people use them in 
 places like the playground to specify the reader properties and then they copy paste into mule and it doesn't work.
 
@@ -10,9 +10,9 @@ I've been thinking on alternatives to this.
 
 This is a valid option but I think there is value in input directives. One is that if you want to create a re-usable mapping,
 declaring your inputs and their types helps consumers understand about the mapping how it needs to be called. Also there are things
-like `@StreamCapable` that are usefull verifications that only works if they are present.
+like `@StreamCapable` that are useful verifications that only works if they are present.
 
-## Option 1: Deprecate The Format dependendent part of Input Directives
+## Option 2: Deprecate The Format dependent part of Input Directives
 
 If we take the input directive we can identify two parts
 
@@ -21,7 +21,7 @@ If we take the input directive we can identify two parts
 input <name><:typeDefinition>? <mimeType|formatId> <readerProperties*>
 ```
 
-Form this pseudo grammar we dan spot two parts the variable definition section 
+From this pseudo grammar we can spot two parts the variable definition section 
 
 ```
 <annotations>*

--- a/proposals/TypeParameters.md
+++ b/proposals/TypeParameters.md
@@ -20,12 +20,12 @@ When this happens in order to infer the type of T a set of constrains are built
 
 
 
-| Expected | Actural | 
+| Expected | Actual | 
 | -------- | --------|
 | T        | String  |
 
 
-Then the solution is simple `T` needs to be of Type `String` then it will substitue the result with this solution. `T <= String` 
+Then the solution is simple `T` needs to be of Type `String` then it will substitute the result with this solution. `T <= String` 
 
 This is a very simple example but it shows the basics of how the type parameter inference works.
 
@@ -47,14 +47,14 @@ Expecting Type: `"2"`, but got: `"a"`.
 	|---- From: AnonymousFunction($: `"2"`) -> `"2"`
 ```
 
-And why is this? Is beacuse from `defaultValue("2")` it will infere a `(
+And why is this? It is because from `defaultValue("2")` it will infer a `(
 "2") -> "2" ` That is not exactly what we want. 
 
-We have been hacking the TypeParamerter solver to be able to express different behaviours, but we will continue hitting limitations.
+We have been hacking the TypeParameter solver to be able to express different behaviours, but we will continue hitting limitations.
 
 ## Solution
 
-The solution is quite simple, add a sintax for expressing the type binding on a function call 
+The solution is quite simple, add a syntax for expressing the type binding on a function call 
 
 functionExpression<ParamBinding*>?(Params*)
 
@@ -75,7 +75,7 @@ This will start working as now `defaultValue<String>` will replace T with String
 ### All or nothing
 
 
-We are only going to allow to either specify all the type parameters or non but not to parcially apply.
+We are only going to allow to either specify all the type parameters or non but not to partially apply.
 
 So for example
 
@@ -97,5 +97,5 @@ We need to validate that the specified substitution is valid
 fun test<T <: String, Q>(a: T, b: Q): {a: T, b: Q} = ???
 ```
 
-In this case `test<"Mariano", Number>("Mariano", 32)` is valid as `"Mariano" < String` but `test<Number, Number>(123, 32)` should complain as `Number` is not a valid subsitution for `T` as `Number < String` is *false*
+In this case `test<"Mariano", Number>("Mariano", 32)` is valid as `"Mariano" < String` but `test<Number, Number>(123, 32)` should complain as `Number` is not a valid substitution for `T` as `Number < String` is *false*
 

--- a/proposals/TypeSelection.md
+++ b/proposals/TypeSelection.md
@@ -11,15 +11,15 @@ type User = {name: String}
 type NameType = User.name
 ```
 
-With this option it will allow us to reference a type from any object with out the need to refactoring.
+With this option it will allow us to reference a type from any object without the need to refactoring.
 
 ## Supported selections
 
-There are two kind of selections static and dynamic selections. 
+There are two kinds of selections static and dynamic selections. 
 
 ### Static selection
 
-For static selections we should support both with and without namesapce. A question would be if we want to do the same matching. 
+For static selections we should support both with and without namespace. A question would be if we want to do the same matching. 
 
 *For example*
 
@@ -34,7 +34,7 @@ type User = {
 type A = User.name
 ```
 
-If the type selection follows the runtime semantics type `A` should be String, but I think that it should return `Number`. This may introduce some noice but I think is much clear.
+If the type selection follows the runtime semantics type `A` should be String, but I think that it should return `Number`. This may introduce some noise but I think is much clearer.
 
 
 So to have the `String` type the expression should be like
@@ -60,7 +60,7 @@ For dynamic selections this can be achieved with the mix of type parameters + li
 fun test<T <: String, Q :< {}>(fieldName: T, a: Q): Q[T] = a[fieldName]
 ```
 
-This scenario has is hard to validate and this will only add value when `T` is a literal type. 
+This scenario is hard to validate and this will only add value when `T` is a literal type. 
 
 For example what would this expression return
 
@@ -73,9 +73,9 @@ For example what would this expression return
 I think that we should investigate dynamic and static in separate threads and maybe in different stages
 
 
-## Buisness need behind
+## Business need behind
 
-The need to support this cames because currently DW is the default language for transfroming any data format into another, but we want to extend this for type. We want to make DW the default language to be able to interact with any type schema. JsonSchema, XmlSchema, etc. This introduces one problem is that those schema formats are fixed and can not be refactored to extract parts of those schemas. Moreover we don't have a way to have a propper support for XMLSchema and this is because each element in a XMLSchema has a namespace and we don't have a way to put namespaces on our variables nor it makes sense to do so. 
+The need to support this cames because currently DW is the default language for transforming any data format into another, but we want to extend this for type. We want to make DW the default language to be able to interact with any type schema. JsonSchema, XmlSchema, etc. This introduces one problem is that those schema formats are fixed and cannot be refactored to extract parts of those schemas. Moreover we don't have a way to have a proper support for XMLSchema and this is because each element in a XMLSchema has a namespace and we don't have a way to put namespaces on our variables nor it makes sense to do so. 
 
 
 So for example for a schema like
@@ -167,8 +167,8 @@ var orders: Array<Order> = [
 ```
 
 
-## Releated Work
+## Related Work
 
-Typescript has a similar behaviour called indexed access.
+TypeScript has a similar behaviour called indexed access.
 
 - https://www.typescriptlang.org/docs/handbook/2/indexed-access-types.html

--- a/text/0001-update-syntax.md
+++ b/text/0001-update-syntax.md
@@ -13,14 +13,14 @@ This feature adds an easy way to update single values in nested data structures 
 # Motivation
 [motivation]: #motivation
 
-This feature should be added because currently an end-user needs to know about functional recursion and probably pattern matching should they want to update a single field in a data structure without touching any of the other ones. This is a problem because DataWeave currently makes a simple, commonly used pattern (updating a single value in a nested data structure) and puts it out of reach of your average integration programmer than is not familiar with functional programming (FP).
+This feature should be added because currently an end-user needs to know about functional recursion and probably pattern matching should they want to update a single field in a data structure without touching any of the other ones. This is a problem because DataWeave currently makes a simple, commonly used pattern (updating a single value in a nested data structure) and puts it out of reach of your average integration programmer that is not familiar with functional programming (FP).
 
 The expected outcome is that DataWeave users will no longer need to know to use recursion and pattern matching when they want to update a single value, they will just need to know the `update` syntax.
 
 # Documentation
 [documentation]: #documentation
 
-As this feature proposes a new syntax, and not just new functions, documentation must adequately explain what is valid and what is invalid syntax for `update`. That being said, the leap from knowing nothing about `update`, to being able to effectively use it should be a small one. This syntax reuses a couple pieces of functuionality that DataWeave users are already familiar with, pattern matching and the selector syntax. Instead of `case is ...` this syntax uses `case at ...` followed by the afformentioned selector syntax. Here are some examples:
+As this feature proposes a new syntax, and not just new functions, documentation must adequately explain what is valid and what is invalid syntax for `update`. That being said, the leap from knowing nothing about `update`, to being able to effectively use it should be a small one. This syntax reuses a couple pieces of functionality that DataWeave users are already familiar with, pattern matching and the selector syntax. Instead of `case is ...` this syntax uses `case at ...` followed by the aforementioned selector syntax. Here are some examples:
 
 ## Updating with literals
 
@@ -92,7 +92,7 @@ null update { case at .foo -> "hello" }
 
 
 ## Updating repeated keys
-It's necessary to support repeated keys on the same Object in DataWeave. Because of this, an edge case exists where DataWeave cannot intepret what's between `case` and `->` exactly as selectors. Imagine the following example:
+It's necessary to support repeated keys on the same Object in DataWeave. Because of this, an edge case exists where DataWeave cannot interpret what's between `case` and `->` exactly as selectors. Imagine the following example:
 
 ```dwl
 {a: [1,2,3], a: [4,5,6]} update {
@@ -102,7 +102,7 @@ It's necessary to support repeated keys on the same Object in DataWeave. Because
 
 If the user views `.*a` as functioning exactly like the multi-value selector, then the lambda would be called once with `[[1,2,3],[4,5,6]]`. This creates an ambiguity. Given that this Array could then be transformed into anything, it becomes impossible to determine how the modifications to the Array should be applied back to the original data. Does DataWeave update the first `a`, the second `a`, or both?
 
-The solution for this requires that the "selector" syntax used in `update` functional slightly differently when matching repeated keys. The lambda on the RHS of `->` is called twice, because `.*a` matched on two values. When the lambda is called the first time, the result is applied to the first `a`, when it is called the second time, the result is applied to the second `a`. Updating individual values requires the use of a guard.
+The solution for this requires that the "selector" syntax used in `update` functions slightly differently when matching repeated keys. The lambda on the RHS of `->` is called twice, because `.*a` matched on two values. When the lambda is called the first time, the result is applied to the first `a`, when it is called the second time, the result is applied to the second `a`. Updating individual values requires the use of a guard.
 
 ### Updating all repeated keys with the same lambda
 
@@ -222,7 +222,7 @@ do {
 # Drawbacks
 [drawbacks]: #drawbacks
 
-This feature adds additional syntax to the language which is, generally speaking, something not taken lightly with programming languages. This feature could conceivably be added as a few additional functions, but the ergonomics of it would not be as nice (see Rational, Alternatives). Personally, I think there's a much greater drawback in not having `update` syntax as a part of the language.
+This feature adds additional syntax to the language which is, generally speaking, something not taken lightly with programming languages. This feature could conceivably be added as a few additional functions, but the ergonomics of it would not be as nice (see Rationale, Alternatives). Personally, I think there's a much greater drawback in not having `update` syntax as a part of the language.
 
 # Rationale, Alternatives
 [rationale]: #rationale

--- a/text/0002-temporal-consistency.md
+++ b/text/0002-temporal-consistency.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-Currently, DW can be a bit inconsistent when dealing with temporal objects like `Date`, `DateTime`, `LocalDateTime`, `Time`, `LocalTime`, and `Period`. I'll refer to `Date`, `DateTime`, `LocaldateTime`, `Time`, and `LocalTime` as "temporal instances" throughout the RFC, as they identify a specific point in time. This RFC is a proposal on how that can be addressed.
+Currently, DW can be a bit inconsistent when dealing with temporal objects like `Date`, `DateTime`, `LocalDateTime`, `Time`, `LocalTime`, and `Period`. I'll refer to `Date`, `DateTime`, `LocalDateTime`, `Time`, and `LocalTime` as "temporal instances" throughout the RFC, as they identify a specific point in time. This RFC is a proposal on how that can be addressed.
 
 # Motivation
 [motivation]: #motivation
@@ -130,7 +130,7 @@ In the event that `decomposeTemporal` is passed the wrong type, it should throw 
 
 The documentation could be a bit more verbose about the difference between temporal instances and `Periods`. It doesn't say that `Period` represents a length of time. It also doesn't disclose that the actual length of a `Period` is unknown until it is applied to a temporal instance. If the `decomposeTemporal` function is included in the language, it should be stated in the documentation that the keys returned in the object mean something conceptually different when passing a temporal instance vs a `Period`. In the case of a temporal instance, the keys represent where the instance falls on a time line, including some additional information. In the case of `Period`s, the keys represent how many of each of the durations will be ultimately applied to the temporal instance.
 
-In addition to this, the documentation should contain how to interpolate `Period`s. This is currently contained in examples, but I think it would get greater visability on the documentation for the `Period` type:
+In addition to this, the documentation should contain how to interpolate `Period`s. This is currently contained in examples, but I think it would get greater visibility on the documentation for the `Period` type:
 
 `Period`s can be interpolated by creating a period `String` and casting it to a `Period`:
 


### PR DESCRIPTION
## Summary
Fix 40 typos across 7 files:

- **text/0001-update-syntax.md**: functuionality → functionality, afformentioned → aforementioned, intepret → interpret, than → that, functional → functions, Rational → Rationale
- **text/0002-temporal-consistency.md**: LocaldateTime → LocalDateTime, visability → visibility
- **proposals/TypeSelection.md**: with out → without, kind → kinds, namesapce → namespace, noice → noise, has is → is, Buisness → Business, transfroming → transforming, can not → cannot, propper → proper, Releated → Related, Typescript → TypeScript, clear → clearer
- **proposals/TypeParameters.md**: Actural → Actual, beacuse → because, infere → infer, TypeParamerter → TypeParameter, sintax → syntax, parcially → partially, subsitution → substitution, substitue → substitute
- **proposals/Directives.md**: specially → especially, usefull → useful, dependendent → dependent, Option 1 → Option 2 (duplicate heading), Form → From, dan → can
- **blogs/Streaming.md**: kind → kinds, inmutable → immutable, sequencial → sequential (6×), scape → escape, secuencial maner → sequential manner, reference → referenced, access → accessed, breakes → breaks, refrence → reference, garanties → guarantees, an is → and is
- **README.md**: substaintial → substantial

No functional changes — documentation only.